### PR TITLE
XL3 format support for rgb2sdas (banked code and data for GBDK)

### DIFF
--- a/hUGEDriver.asm
+++ b/hUGEDriver.asm
@@ -1,4 +1,4 @@
-include "include/hardware.inc"
+include "include/HARDWARE.INC"
 include "include/hUGE.inc"
 
 add_a_to_r16: MACRO
@@ -157,11 +157,15 @@ highmask4: db
 
 _end_vars:
 
-SECTION "Sound Driver", ROM0
+SECTION "Sound Driver", ROMX
 
+_hUGE_init_banked::
+    ld hl, sp+2+4
+    jr continue_init
 _hUGE_init::
+    ld hl, sp+2
+continue_init:
     push bc
-    ld hl, sp+4
     ld a, [hl+]
     ld h, [hl]
     ld l, a
@@ -169,9 +173,13 @@ _hUGE_init::
     pop bc
     ret
 
+_hUGE_mute_channel_banked::
+    ld hl, sp+3+4
+    jr continue_mute
 _hUGE_mute_channel::
+    ld hl, sp+3
+continue_mute:
     push bc
-    ld hl, sp+5
     ld a, [hl-]
     and 1
     ld c, a
@@ -1270,6 +1278,7 @@ checkMute: MACRO
     jp nz, \2
 ENDM
 
+_hUGE_dosound_banked::
 _hUGE_dosound::
     ld a, [tick]
     or a

--- a/include/hUGEDriver.h
+++ b/include/hUGEDriver.h
@@ -91,13 +91,16 @@ typedef struct hUGESong_t {
 
 // initialize the driver with song data
 void hUGE_init(const hUGESong_t * song);
+void hUGE_init_banked(const hUGESong_t * song) __banked;
 
 // driver routine
 void hUGE_dosound();
+void hUGE_dosound_banked() __banked;
 
 enum hUGE_channel_t {HT_CH1 = 0, HT_CH2, HT_CH3, HT_CH4};
 enum hUGE_mute_t    {HT_CH_PLAY = 0, HT_CH_MUTE};
 
 void hUGE_mute_channel(enum hUGE_channel_t ch, enum hUGE_mute_t mute);
+void hUGE_mute_channel_banked(enum hUGE_channel_t ch, enum hUGE_mute_t mute) __banked;
 
 #endif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,5 @@
+all: clean
+	fpc -B rgb2sdas.pas
+clean:
+	rm -f *.o
+	rm -f *.exe


### PR DESCRIPTION
code for banked gbdk player:
```
void ISR_wrapper() { hUGE_dosound_banked(); }
void main() {
    __critical {
        hUGE_init_banked(&Intro);
        add_VBL(ISR_wrapper);
    }
...
}
```
converter parameters: `rgb2sdas -b2 build\hUGEDriver.obj`
then compile song data also to bank2: `lcc -Wf-bo2 -c -o build\song.obj song/C/song.c`
so we get driver and data both in bank2, that works nice.