### PR TITLE
Make `return_dont_call_playnote` less fragile

### DIFF
--- a/hUGEDriver.asm
+++ b/hUGEDriver.asm
@@ -30,8 +30,8 @@ ENDM
 ret_dont_call_playnote: MACRO
     pop hl
     pop af
-    ld a, 4 ; How many bytes until the next channel's code
-    add_a_to_hl
+    and a ; Clear carry to avoid calling `play_chX_note`
+    push af
     jp hl
 ENDM
 
@@ -1289,8 +1289,8 @@ hUGE_dosound::
     ld e, 0
     call do_effect
 
-    pop af              ; 1 byte
-    call c, play_ch1_note     ; 3 bytes
+    pop af
+    call c, play_ch1_note
 
 .after_note1:
     ;; Note playback
@@ -1329,8 +1329,8 @@ hUGE_dosound::
     ld e, 1
     call do_effect
 
-    pop af              ; 1 byte
-    call c, play_ch2_note     ; 3 bytes
+    pop af
+    call c, play_ch2_note
 
 .after_note2:
     loadShort pattern3, b, c
@@ -1392,8 +1392,8 @@ ENDR
     ld e, 2
     call do_effect
 
-    pop af              ; 1 byte
-    call c, play_ch3_note     ; 3 bytes
+    pop af
+    call c, play_ch3_note
 
 .after_note3:
     loadShort pattern4, b, c
@@ -1444,8 +1444,8 @@ ENDR
     ld e, 3
     call do_effect
 
-    pop af              ; 1 byte
-    call c, play_ch4_note     ; 3 bytes
+    pop af
+    call c, play_ch4_note
 
 .after_note4:
     ;; finally just update the tick/order/row values


### PR DESCRIPTION
Change the flag being checked for instead of manipulating return address