### PR TITLE
Some micro optimizations

### DIFF
--- a/hUGEDriver.asm
+++ b/hUGEDriver.asm
@@ -422,13 +422,13 @@ update_channel_freq:
 .nonzero_highmask:
     ld c, b
     ld a, [mute_channels]
+
     dec c
     jr z, .update_channel2
     dec c
     jr z, .update_channel3
     dec c
     jr z, .update_channel4
-
 .update_channel1:
     retMute 0
 
@@ -440,7 +440,6 @@ update_channel_freq:
     or h
     ldh [rAUD1HIGH], a
     ret
-
 .update_channel2:
     retMute 1
 
@@ -480,12 +479,32 @@ update_channel_freq:
     ret
 
 
-play_note_routines:
-    jr play_ch1_note
-    jr play_ch2_note
-    jr play_ch3_note
-    jr play_ch4_note
+;;; Processes effect 7, "note delay".
+;;; Param: B = Current channel ID (0 = CH1, 1 = CH2, etc.)
+;;; Param: C = Amount of ticks by which to delay the note
+;;;            Caveats: 0 never plays the note, and a delay longer than a row's duration skips the note entirely
+;;; Param: ZF = Set if and only if on tick 0
+;;; Destroy: AF D HL
+fx_note_delay:
+    jr z, ret_dont_play_note
 
+    cp c
+    ret nz ; wait until the correct tick to play the note
+
+    ;; fallthrough
+
+
+;;; Plays a channel's current note.
+;;; Param: B = Which channel (0 = CH1, 1 = CH2, etc.)
+;;; Destroy: AF HL
+play_note:
+    ; this is faster than a jump table
+    ld a, b
+    rra
+    jr c, ch2_or_ch4
+ch1_or_ch3:
+    rra
+    jr c, play_ch3_note
 play_ch1_note:
     ld a, [mute_channels]
     retMute 0
@@ -500,7 +519,9 @@ play_ch1_note:
     or [hl]
     ldh [rAUD1HIGH], a
     ret
-
+ch2_or_ch4:
+    rra
+    jr c, play_ch4_note
 play_ch2_note:
     ld a, [mute_channels]
     retMute 1
@@ -515,7 +536,9 @@ play_ch2_note:
     or [hl]
     ldh [rAUD2HIGH], a
     ret
-
+ch3_or_ch4:
+    rra
+    jr c, play_ch4_note
 play_ch3_note:
     ld a, [mute_channels]
     retMute 2
@@ -804,7 +827,7 @@ fx_set_duty:
     call update_ch3_waveform
 
     ld b, 2
-    jp play_note
+    jp jr
 
 update_ch3_waveform:
     ld [hl], a
@@ -1078,29 +1101,14 @@ fx_arpeggio:
     dec a
 
     ;; TODO: A crappy modulo, because it's not a multiple of four :(
-
-    jr .test_greater_than_two
-.greater_than_two:
+.mod3_loop:
     sub 3
-.test_greater_than_two:
-    cp 3
-    jr nc, .greater_than_two
+    jr nc, .mod3_loop
+    add 3
 
-    ;; Multiply by 2 to get offset into table
-    add a
-
-    add LOW(.arp_options)
-    ld l, a
-    adc HIGH(.arp_options)
-    sub l
-    ld h, a
-    jp hl
-
-.arp_options:
-    jr .set_arp1
-    jr .set_arp2
-    ;; No `jr .reset_arp`
-
+    jr z, .set_arp1
+    dec a
+    jr z, .set_arp2
 .reset_arp:
     ld a, d
     jr .finish_skip_add
@@ -1265,7 +1273,7 @@ fx_toneporta:
     ld a, l
     ld [de], a
 
-ret_dont_play_note:
+ret_dont_jr:
     ;; Don't call play_chX_note. This is done by popping the saved AF register and clearing
     ;; the C flag, which relies on the way the caller is implemented!!
     pop hl
@@ -1353,37 +1361,11 @@ fx_vol_slide:
     or %10000000
     ldh [c], a
 
-    jr play_note
+    jp jr
 
 
-;;; Processes effect 7, "note delay".
-;;; Param: B = Current channel ID (0 = CH1, 1 = CH2, etc.)
-;;; Param: C = Amount of ticks by which to delay the note
-;;;            Caveats: 0 never plays the note, and a delay longer than a row's duration skips the note entirely
-;;; Param: ZF = Set if and only if on tick 0
-;;; Destroy: AF D HL
-fx_note_delay:
-    jr z, ret_dont_play_note
 
-    cp c
-    ret nz ; wait until the correct tick to play the note
-
-    ;; fallthrough
-
-
-;;; Plays a channel's current note.
-;;; Param: B = Which channel (0 = CH1, 1 = CH2, etc.)
-;;; Destroy: AF D HL
-play_note:
-    ld a, b
-    add a
-    add LOW(play_note_routines)
-    ld l, a
-    adc HIGH(play_note_routines)
-    sub l
-    ld h, a
-    jp hl
-
+;;; Effect 7 defition has been moved to just before play_note in order to allow for fallthrough
 
 ;;; Computes the pointer to an instrument.
 ;;; Param: B = The instrument's ID

--- a/hUGEDriver.asm
+++ b/hUGEDriver.asm
@@ -415,20 +415,19 @@ ptr_to_channel_member:
 ;;; Param: B = Which channel to update (0 = CH1, 1 = CH2, etc.)
 ;;; Param: (for CH4) E = Note ID
 ;;; Param: (otherwise) DE = Note period
-;;; Destroy: AF C
+;;; Destroy: AF
 ;;; Destroy: (for CH4) HL
 update_channel_freq:
     ld h, 0
 .nonzero_highmask:
-    ld c, b
+    ld a, b
+    rra
+    dec a
     ld a, [mute_channels]
 
-    dec c
-    jr z, .update_channel2
-    dec c
-    jr z, .update_channel3
-    dec c
-    jr z, .update_channel4
+    jr c, .update_ch2_or_ch4
+.update_ch1_or_ch3:
+    jr z, update_ch3
 .update_channel1:
     retMute 0
 
@@ -440,6 +439,8 @@ update_channel_freq:
     or h
     ldh [rAUD1HIGH], a
     ret
+.update_ch2_or_ch4:
+    jr z, .update_channel4
 .update_channel2:
     retMute 1
 
@@ -476,115 +477,6 @@ update_channel_freq:
 
     ld a, d
     ldh [rAUD4GO], a
-    ret
-
-
-;;; Processes effect 7, "note delay".
-;;; Param: B = Current channel ID (0 = CH1, 1 = CH2, etc.)
-;;; Param: C = Amount of ticks by which to delay the note
-;;;            Caveats: 0 never plays the note, and a delay longer than a row's duration skips the note entirely
-;;; Param: ZF = Set if and only if on tick 0
-;;; Destroy: AF D HL
-fx_note_delay:
-    jr z, ret_dont_play_note
-
-    cp c
-    ret nz ; wait until the correct tick to play the note
-
-    ;; fallthrough
-
-
-;;; Plays a channel's current note.
-;;; Param: B = Which channel (0 = CH1, 1 = CH2, etc.)
-;;; Destroy: AF HL
-play_note:
-    ; this is faster than a jump table
-    ld a, b
-    rra
-    jr c, ch2_or_ch4
-ch1_or_ch3:
-    rra
-    jr c, play_ch3_note
-play_ch1_note:
-    ld a, [mute_channels]
-    retMute 0
-
-    ;; Play a note on channel 1 (square wave)
-    ld hl, channel_period1
-    ld a, [hl+]
-    ldh [rAUD1LOW], a
-
-    ;; Get the highmask and apply it.
-    ld a, [highmask1]
-    or [hl]
-    ldh [rAUD1HIGH], a
-    ret
-ch2_or_ch4:
-    rra
-    jr c, play_ch4_note
-play_ch2_note:
-    ld a, [mute_channels]
-    retMute 1
-
-    ;; Play a note on channel 2 (square wave)
-    ld hl, channel_period2
-    ld a, [hl+]
-    ldh [rAUD2LOW], a
-
-    ;; Get the highmask and apply it.
-    ld a, [highmask2]
-    or [hl]
-    ldh [rAUD2HIGH], a
-    ret
-ch3_or_ch4:
-    rra
-    jr c, play_ch4_note
-play_ch3_note:
-    ld a, [mute_channels]
-    retMute 2
-
-    ;; Triggering CH3 while it's reading a byte corrupts wave RAM.
-    ;; To avoid this, we kill the wave channel (0 → NR30), then re-enable it.
-    ;; This way, CH3 will be paused when we trigger it by writing to NR34.
-    ;; TODO: what if `highmask3` bit 7 is not set, though?
-
-    ldh a, [rAUDTERM]
-    push af
-    and %10111011
-    ldh [rAUDTERM], a
-
-    xor a
-    ldh [rAUD3ENA], a
-    cpl
-    ldh [rAUD3ENA], a
-
-    ;; Play a note on channel 3 (waveform)
-    ld hl, channel_period3
-    ld a, [hl+]
-    ldh [rAUD3LOW], a
-
-    ;; Get the highmask and apply it.
-    ld a, [highmask3]
-    or [hl]
-    ldh [rAUD3HIGH], a
-
-    pop af
-    ldh [rAUDTERM], a
-
-    ret
-
-play_ch4_note:
-    ld a, [mute_channels]
-    retMute 3
-
-    ;; Play a "note" on channel 4 (noise)
-    ld a, [channel_period4]
-    ldh [rAUD4POLY], a
-
-    ;; Get the highmask and apply it.
-    ld a, [highmask4]
-    ldh [rAUD4GO], a
-
     ret
 
 ;;; Executes a row of a table.
@@ -1089,7 +981,7 @@ fx_vibrato:
 ;;; Param: B = Current channel ID (0 = CH1, 1 = CH2, etc.)
 ;;; Param: C = Offsets in semitones (each nibble)
 ;;; Param: ZF = Set if and only if on tick 0
-;;; Destroy: AF B DE HL
+;;; Destroy: AF DE HL
 fx_arpeggio:
     nop ; In place of `ret cc`. Allows to be used in subpatterns
 
@@ -1104,26 +996,17 @@ fx_arpeggio:
 .mod3_loop:
     sub 3
     jr nc, .mod3_loop
-    add 3
 
-    jr z, .set_arp1
-    dec a
-    jr z, .set_arp2
-.reset_arp:
-    ld a, d
-    jr .finish_skip_add
-
-.set_arp2:
+    inc a
+    jr z, .reset_arp
+    inc a
     ld a, c
+    jr nz, .finish_arp
     swap a
-    db $FE ; cp <imm8> gobbles next byte
-
-.set_arp1:
-    ld a, c
 .finish_arp:
     and %00001111
+.reset_arp:
     add d
-.finish_skip_add:
     call get_note_period
     ld d, h
     ld e, l
@@ -1361,11 +1244,108 @@ fx_vol_slide:
     or %10000000
     ldh [c], a
 
-    jp play_note
+    jr play_note
 
+;;; Processes effect 7, "note delay".
+;;; Param: B = Current channel ID (0 = CH1, 1 = CH2, etc.)
+;;; Param: C = Amount of ticks by which to delay the note
+;;;            Caveats: 0 never plays the note, and a delay longer than a row's duration skips the note entirely
+;;; Param: ZF = Set if and only if on tick 0
+;;; Destroy: AF D HL
+fx_note_delay:
+    jp z, ret_dont_play_note
 
+    cp c
+    ret nz ; wait until the correct tick to play the note
 
-;;; Effect 7 defition has been moved to just before play_note in order to allow for fallthrough
+    ;; fallthrough
+
+;;; Plays a channel's current note.
+;;; Param: B = Which channel (0 = CH1, 1 = CH2, etc.)
+;;; Destroy: AF HL
+play_note:
+    ; this is faster than a jump table
+    ld a, b
+    rra
+    dec a
+    ld a, [mute_channels]
+    jr c, play_ch2_or_ch4
+play_ch1_or_ch3:
+    jr z, play_ch3_note
+play_ch1_note:
+    retMute 0
+
+    ;; Play a note on channel 1 (square wave)
+    ld hl, channel_period1
+    ld a, [hl+]
+    ldh [rAUD1LOW], a
+
+    ;; Get the highmask and apply it.
+    ld a, [highmask1]
+    or [hl]
+    ldh [rAUD1HIGH], a
+    ret
+play_ch2_or_ch4:
+    jr z, play_ch4_note
+play_ch2_note:
+    retMute 1
+
+    ;; Play a note on channel 2 (square wave)
+    ld hl, channel_period2
+    ld a, [hl+]
+    ldh [rAUD2LOW], a
+
+    ;; Get the highmask and apply it.
+    ld a, [highmask2]
+    or [hl]
+    ldh [rAUD2HIGH], a
+    ret
+play_ch3_note:
+    retMute 2
+
+    ;; Triggering CH3 while it's reading a byte corrupts wave RAM.
+    ;; To avoid this, we kill the wave channel (0 → NR30), then re-enable it.
+    ;; This way, CH3 will be paused when we trigger it by writing to NR34.
+    ;; TODO: what if `highmask3` bit 7 is not set, though?
+
+    ldh a, [rAUDTERM]
+    push af
+    and %10111011
+    ldh [rAUDTERM], a
+
+    xor a
+    ldh [rAUD3ENA], a
+    cpl
+    ldh [rAUD3ENA], a
+
+    ;; Play a note on channel 3 (waveform)
+    ld hl, channel_period3
+    ld a, [hl+]
+    ldh [rAUD3LOW], a
+
+    ;; Get the highmask and apply it.
+    ld a, [highmask3]
+    or [hl]
+    ldh [rAUD3HIGH], a
+
+    pop af
+    ldh [rAUDTERM], a
+
+    ret
+
+play_ch4_note:
+    retMute 3
+
+    ;; Play a "note" on channel 4 (noise)
+    ld a, [channel_period4]
+    ldh [rAUD4POLY], a
+
+    ;; Get the highmask and apply it.
+    ld a, [highmask4]
+    ldh [rAUD4GO], a
+
+    ret
+
 
 ;;; Computes the pointer to an instrument.
 ;;; Param: B = The instrument's ID

--- a/hUGEDriver.asm
+++ b/hUGEDriver.asm
@@ -827,7 +827,7 @@ fx_set_duty:
     call update_ch3_waveform
 
     ld b, 2
-    jp jr
+    jp play_note
 
 update_ch3_waveform:
     ld [hl], a
@@ -1361,7 +1361,7 @@ fx_vol_slide:
     or %10000000
     ldh [c], a
 
-    jp jr
+    jp play_note
 
 
 


### PR DESCRIPTION
I replaced 1 jump table used in play_note and one "linear" switch used in update_channel_freq with binary search switch, which is faster since there is only 4 possible cases to test for.
Because of the changes to play_note, i was able to factor the `ld a, [mute_channels]` accross all 4 branches.
Because of the changes to update_channel_freq, it now preserve the content of the C register.

I also changed quite a bit the structure of the code in fx_arpeggio, the loop that computes the modulus dont perform unecessary checks anymore, and a jump table is no longer used (this is costly when there is only 3 different cases), which allows for further optimizations.

I wasn't able to test for unexpected behaviour on the rest of the library since the base file can not play a sample correctly
Overall these changes reduced by more than 16 bytes, and should slightly improve the average speed.